### PR TITLE
include_children parameter

### DIFF
--- a/pydocparser/__init__.py
+++ b/pydocparser/__init__.py
@@ -171,7 +171,7 @@ class Parser:
 
         return message
 
-    def get_one_result(self, parser_label: str, document_id: str) -> Union[str, dict]:
+    def get_one_result(self, parser_label: str, document_id: str, include_children: Optional[boolean]=False) -> Union[str, dict]:
         """
         Get a specific document result from the given parser by document_id
 
@@ -184,7 +184,10 @@ class Parser:
         if not parser_id:
             return "Unable to find parser"
 
-        result = requests.get(self.BASE_URL + "/results/{}/{}".format(parser_id, document_id), auth=self.AUTH)
+        if include_children:
+            result = requests.get(self.BASE_URL + "/results/{}/{}/?include_children=true/".format(parser_id, document_id), auth=self.AUTH)
+        else:
+            result = requests.get(self.BASE_URL + "/results/{}/{}".format(parser_id, document_id), auth=self.AUTH)
 
         # This needs its own error checking because status 400 isn't always a bad thing
         if result.status_code == 403:

--- a/pydocparser/__init__.py
+++ b/pydocparser/__init__.py
@@ -8,7 +8,11 @@ __contact__ = "stautonico@gmail.com"
 __date__ = "6/3/2021"
 __version__ = 2.0
 
-from typing import Optional, Union, List, Literal
+try:
+    from typing import Literal
+except:
+    from typing_extensions import Literal
+from typing import Optional, Union, List
 
 
 class Parser:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.22.0
 setuptools==57.0.0
 pdoc3==0.9.2
+typing_extensions==3.7.4.3


### PR DESCRIPTION
Hi,
I am using DocParser with some preprocessing on a parser (`PARSER` > Settings > Preprocessing), more specifically the splitting procedure (Split documents when importing). I use it to split a document if DocParser spots that there are many invoices in the same file. This splitting procedure is linked to the argument `include_children`. I have to put it to `True`, otherwise I can't use `pydocparser` on my model.

When using `pydocparser`, I can't actually use the `include_children` parameter, which raises an error when calling `get_one_result()`. 

```
{'error': 'Document was replaced by splitting procedure. Use include_children parameter to obtain parsing results of documents created by splitting procedure.'}
```

SOLUTION:
I have successfully modified the code to welcome the `include_children` parameter. See below.

```
    def get_one_result(self, parser_label: str, document_id: str, include_children: Optional[boolean]=False) -> Union[str, dict]:
        """
        Get a specific document result from the given parser by document_id
        :param parser_label: The label of the parser to retrieve the document result from
        :param document_id: The id of the document to receive
        :return: A string error message or a dict containing the document result
        """
        parser_id = self._find_parser_id(parser_label)

        if not parser_id:
            return "Unable to find parser"

        if include_children:
            result = requests.get(self.BASE_URL + "/results/{}/{}/?include_children=true/".format(parser_id, document_id), auth=self.AUTH)
        else:
            result = requests.get(self.BASE_URL + "/results/{}/{}".format(parser_id, document_id), auth=self.AUTH)

        # This needs its own error checking because status 400 isn't always a bad thing
        if result.status_code == 403:
            return "Invalid API key, use Parser.login(api_key)"
        else:
            return loads(result.text)
```

Also, I installed another package, `typing_extensions` in order to import Literal, since we can't import Literal from typing with a Python version prior to 3.7.7 (see [this thread](https://stackoverflow.com/questions/61206437/importerror-cannot-import-name-literal-from-typing)).


Thanks,
Thomas Monnier @papernest